### PR TITLE
Set host to 0.0.0.0 to allow external access

### DIFF
--- a/run.py
+++ b/run.py
@@ -5,4 +5,4 @@ PORT = app.config.get('PORT', 5000)
 
 app.logger.info('Starting port {port}'.format(port=PORT))
 
-socketio.run(app, port=PORT)
+socketio.run(app, host="0.0.0.0", port=PORT)


### PR DESCRIPTION
The application doesn't work if connecting via an IP address (or `127.0.0.1`) because Flask doesn't listen to every host by default, just to localhost